### PR TITLE
Expose option for class specific filtering.

### DIFF
--- a/keras_maskrcnn/bin/train.py
+++ b/keras_maskrcnn/bin/train.py
@@ -54,10 +54,16 @@ def model_with_weights(model, weights, skip_mismatch):
     return model
 
 
-def create_models(backbone_retinanet, num_classes, weights, freeze_backbone=False):
+def create_models(backbone_retinanet, num_classes, weights, freeze_backbone=False, class_specific_filter=True):
     modifier = freeze_model if freeze_backbone else None
 
-    model            = model_with_weights(backbone_retinanet(num_classes, nms=True, modifier=modifier), weights=weights, skip_mismatch=True)
+    model            = model_with_weights(
+        backbone_retinanet(
+            num_classes,
+            nms=True,
+            class_specific_filter=class_specific_filter,
+            modifier=modifier
+        ), weights=weights, skip_mismatch=True)
     training_model   = model
     prediction_model = model
 
@@ -218,6 +224,7 @@ def parse_args(args):
     parser.add_argument('--no-snapshots',    help='Disable saving snapshots.', dest='snapshots', action='store_false')
     parser.add_argument('--no-evaluation',   help='Disable per epoch evaluation.', dest='evaluation', action='store_false')
     parser.add_argument('--freeze-backbone', help='Freeze training of backbone layers.', action='store_true')
+    parser.add_argument('--no-class-specific-filter', help='Disables class specific filtering.', dest='class_specific_filter', action='store_false')
 
     return check_args(parser.parse_args(args))
 
@@ -259,7 +266,8 @@ def main(args=None):
             backbone_retinanet=backbone.maskrcnn,
             num_classes=train_generator.num_classes(),
             weights=weights,
-            freeze_backbone=args.freeze_backbone
+            freeze_backbone=args.freeze_backbone,
+            class_specific_filter=args.class_specific_filter
         )
 
     # print model summary

--- a/keras_maskrcnn/models/retinanet.py
+++ b/keras_maskrcnn/models/retinanet.py
@@ -62,6 +62,7 @@ def retinanet_mask(
     num_classes,
     anchor_parameters=keras_retinanet.models.retinanet.AnchorParameters.default,
     nms=True,
+    class_specific_filter=True,
     name='retinanet-mask',
     roi_submodels=None,
     **kwargs
@@ -115,7 +116,7 @@ def retinanet_mask(
     boxes_masks = ConcatenateBoxesMasks(name='boxes_masks')([top_boxes, masks])
 
     # perform detection filtering
-    detections = keras_retinanet.layers.FilterDetections(nms=nms, name='filtered_detections')([top_boxes, top_classification] + other + [masks])
+    detections = keras_retinanet.layers.FilterDetections(nms=nms, class_specific_filter=class_specific_filter, name='filtered_detections')([top_boxes, top_classification] + other + [masks])
 
     # reconstruct the new output
     outputs = [regression, classification] + other + [boxes_masks] + detections

--- a/keras_maskrcnn/utils/eval.py
+++ b/keras_maskrcnn/utils/eval.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 from __future__ import print_function
 
-from keras_retinanet.utils.visualization import draw_detections, draw_annotations
+from keras_retinanet.utils.visualization import draw_detections
 
 from .overlap import compute_overlap
 from .visualization import draw_masks
@@ -107,7 +107,7 @@ def _get_detections(generator, model, score_threshold=0.05, max_detections=100, 
 
         if save_path is not None:
             # draw_annotations(raw_image, generator.load_annotations(i)[0], label_to_name=generator.label_to_name)
-            draw_detections(raw_image, image_boxes, image_scores, image_labels, label_to_name=generator.label_to_name)
+            draw_detections(raw_image, image_boxes, image_scores, image_labels, score_threshold=score_threshold, label_to_name=generator.label_to_name)
             draw_masks(raw_image, image_boxes.astype(int), image_masks, labels=image_labels)
 
             cv2.imwrite(os.path.join(save_path, '{}.png'.format(i)), raw_image)


### PR DESCRIPTION
This PR exposes a flag to disable class specific filtering. When disabled, each anchor would take the maximum scoring class and use that, instead of using all classes that have a score above a certain threshold.
Should be merged only after the related [PR](https://github.com/fizyr/keras-retinanet/pull/512) in /fizyr/keras-retinanet is merged.