### PR TITLE
Fix loss for dealing with missing annotations.

### DIFF
--- a/keras_maskrcnn/backend/tensorflow_backend.py
+++ b/keras_maskrcnn/backend/tensorflow_backend.py
@@ -31,3 +31,7 @@ def split(*args, **kwargs):
 
 def transpose(*args, **kwargs):
     return tensorflow.transpose(*args, **kwargs)
+
+
+def cond(*args, **kwargs):
+    return tensorflow.cond(*args, **kwargs)


### PR DESCRIPTION
The loss function returns 0 if there are no annotations, the usual loss function if there are.
Should fix #26. 