### PR TITLE
Optimize architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,18 +65,18 @@ maskrcn-train coco /path/to/MS/COCO
 The pretrained MS COCO model can be downloaded [here](https://github.com/fizyr/keras-maskrcnn/releases). Results using the `cocoapi` are shown below (note: the closest resembling architecture in the MaskRCNN paper achieves an mAP of 0.336).
 
 ```
- Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.276
- Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.484
- Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.285
- Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.126
- Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.310
- Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.393
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.278
+ Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.488
+ Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.286
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.127
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.312
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.392
  Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.251
- Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.384
- Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.400
- Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.217
- Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.449
- Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.566
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.386
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.405
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.219
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.452
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.565
 ```
 
 For training on a [custom dataset], a CSV file can be used as a way to pass the data.

--- a/keras_maskrcnn/models/__init__.py
+++ b/keras_maskrcnn/models/__init__.py
@@ -18,7 +18,7 @@ class Backbone(keras_retinanet.models.Backbone):
             'Shape'                 : Shape,
             'ConcatenateBoxes'      : ConcatenateBoxes,
             'ConcatenateBoxesMasks' : ConcatenateBoxes,  # legacy
-            '_mask'                 : losses.mask(),
+            '_mask_conditional'     : losses.mask(),
         })
 
     def maskrcnn(self, *args, **kwargs):


### PR DESCRIPTION
This PR changes the architecture to match more closely the architecture as described in the original paper. Basically, the main difference is that before we were estimating the masks on the top 1k anchors, whereas now we estimate the masks on the top 100 detections (so NMS is applied already). This is in correspondence with their paper:

```
The  mask  branch  is  then applied to the highest scoring 100 detection boxes.
```

Effectively this means processing times go down slightly (in my tests, from roughly 180msec to 150msec) and the memory usage goes down a lot. Before it was using roughly 12gb of memory and complaining that it couldn't acquire enough, now it uses 8.5gb of memory without complaints.

Old models can be updated as follows:

```python
from keras_maskrcnn.models import backbone
model = backbone('resnet50').maskrcnn(<num_classes>)
model.load_weights("/path/to/old/model.h5", by_name=True)
model.save("/path/to/updated/model.h5")
```

This change doesn't affect weights, so theoretically old models work comparable to new models. However, I believe we should bump the version of this package after merging this PR (we should do the same for retinanet btw).