### PR TITLE
Fix bugs in debug.py and retinanet model.

### DIFF
--- a/keras_maskrcnn/bin/debug.py
+++ b/keras_maskrcnn/bin/debug.py
@@ -25,7 +25,7 @@ import numpy as np
 from keras_retinanet.utils.transform import random_transform_generator
 from keras_retinanet.utils.visualization import draw_annotations, draw_boxes, draw_caption
 from keras_retinanet.utils.colors import label_color
-from keras_retinanet.utils.config import read_config_file
+from keras_retinanet.utils.config import read_config_file, parse_anchor_parameters
 from keras_retinanet.utils.anchors import anchors_for_shape, compute_gt_annotations
 
 # Allow relative imports when being executed as script.

--- a/keras_maskrcnn/models/retinanet.py
+++ b/keras_maskrcnn/models/retinanet.py
@@ -115,7 +115,12 @@ def retinanet_mask(
     image_shape = Shape()(image)
 
     if retinanet_model is None:
-        retinanet_model = keras_retinanet.models.retinanet.retinanet(inputs=image, num_classes=num_classes, **kwargs)
+        retinanet_model = keras_retinanet.models.retinanet.retinanet(
+            inputs=image,
+            num_classes=num_classes,
+            num_anchors=anchor_params.num_anchors(),
+            **kwargs
+        )
 
     # parse outputs
     regression     = retinanet_model.outputs[0]


### PR DESCRIPTION
Add a missing import in debug.py, and pass the number of anchors to the generation of the retinanet backbone, so to be able to use an arbitrary amount of anchors (parsed in the config.ini).