### PR TITLE
Fix how overlaps are computed.

### DIFF
--- a/keras_maskrcnn/utils/overlap.py
+++ b/keras_maskrcnn/utils/overlap.py
@@ -28,7 +28,7 @@ def compute_overlap(a, b):
     intersection = np.zeros((a.shape[0], b.shape[0]))
     union        = np.zeros((a.shape[0], b.shape[0]))
     for index, mask in enumerate(a):
-        intersection[index, :] = np.sum(np.count_nonzero(b == mask, axis=1), axis=1)
+        intersection[index, :] = np.sum(np.count_nonzero(b & mask, axis=1), axis=1)
         union[index, :]        = np.sum(np.count_nonzero(b + mask, axis=1), axis=1)
 
     return intersection / union


### PR DESCRIPTION
This PR fixes the way overlaps are computed. Before this PR, the intersection was computed as `np.sum(np.count_nonzero(a == b))`, but this means that if both masks agree on background pixels, then that counts as intersection. The intersection should only count for foreground pixels.